### PR TITLE
Deploy GitHub pages when run in main

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _build/


### PR DESCRIPTION
I think we don't need the deployment before merge the PR.
The changes can avoids the error https://github.com/pauleveritt/tagstr-site/actions/runs/9994728370