### PR TITLE
Fix permisons to commit contents

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: write
+      contents: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Now, the CI can't commit the README file of the permission problem.
https://github.com/koxudaxi/tagstr-docker/actions/runs/10007782613/job/27663183899#step:11:44