### PR TITLE
Use CI Build pyodide

### DIFF
--- a/playground/jupyter-lite.json
+++ b/playground/jupyter-lite.json
@@ -3,7 +3,7 @@
   "jupyter-config-data": {
     "litePluginSettings": {
       "@jupyterlite/pyodide-kernel-extension:kernel": {
-        "pyodideUrl": "https://pauleveritt.github.io/tagstr-site/playground/pyodide/pyodide.js"
+        "pyodideUrl": "https://koxudaxi.github.io/pyodide/pyodide.js"
       }
     }
   }

--- a/playground/jupyter_lite_config.json
+++ b/playground/jupyter_lite_config.json
@@ -1,7 +1,6 @@
 {
   "PipliteAddon": {
     "piplite_urls": [
-      "https://files.pythonhosted.org/packages/73/48/4d2818054671bb272d1b12ca65748a4145dc602a463683b5c21b260becee/ipython-8.26.0-py3-none-any.whl"
     ]
   }
 }


### PR DESCRIPTION
Previously, I used pyodide built on my local machine, but this PR uses pyodide binaries built automatically by GitHubAction.

The build is assumed to run once an hour.
This means that the latest build is immediately available.

https://github.com/koxudaxi/pyodide/releases/tag/aa87323
https://github.com/koxudaxi/pyodide/actions/runs/10026609552