### PR TITLE
Add `dev-playground` make target; update READMEs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ package-lock.json
 
 # Jupyter lite local
 _output/
+.jupyterlite.doit.db
 
 # macOS Finder
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,15 @@ build-playground: install-extras check-jq
 clean-playground:
 	rm -rf playground/dist
 
+# Run a built copy of the playground locally.
 .PHONY: run-playground
 run-playground:
 	source $(VENV_PATH)/bin/activate && cd playground/dist && python -m http.server 8000
+
+# Run the jupyter lite server locally, no build step required.
+.PHONY: dev-playground
+dev-playground:
+	source $(VENV_PATH)/bin/activate && jupyter lite serve --contents playground/content --config playground/jupyter-lite.json
 
 .PHONY: check-jq
 check-jq:

--- a/README.md
+++ b/README.md
@@ -4,16 +4,30 @@ An early stage PEP that introduces tag strings - a natural extension of "f-strin
 
 ## Try tag strings today!
 
-## JupyterLite notebook
+### Tutorial
 
-No installation, no anything. A notebook, in your browser, with the a WASM Python built from the implementation. [Open greet notebook](https://pauleveritt.github.io/tagstr-site/playground/lab/index.html?path=greet.ipynb)
+**Want to read about how tag strings work and how to use them?**
 
-### Using [GitHub Codespaces](https://github.com/features/codespaces)
+[Read the tutorial here](https://pauleveritt.github.io/tagstr-site/).
 
-The fastest way to try tag strings, right in your browser.
 
-1. Go to the [repo homepage](https://github.com/pauleveritt/tagstr-site/?tab=readme-ov-file#try-tag-strings-today)
-1. Click the "Code" button
+### JupyterLite notebooks
+
+**Want to write a little code to experiment with tag strings?**
+
+[Click this link to open an example notebook](https://pauleveritt.github.io/tagstr-site/playground/lab/index.html?path=greet.ipynb) in your browser. No installation is required.
+
+There are several example notebooks to choose from. Here's what they look like:
+
+### Using GitHub Codespaces
+
+**Want to dive a little deeper and/or write code outside of a notebook?**
+
+This repository supports [GitHub Codespaces](https://github.com/features/codespaces).
+
+With a single click, you can spin up a full browser-based development environment using vscode, and backed by a running container image with all the necessary development tools. No local installation is necessary, but you do need a GitHub account.
+
+1. Click the "Code" button on the [home page for this repo](https://github.com/pauleveritt/tagstr-site/?tab=readme-ov-file)
 1. Click the "Codespaces" tab
 1. Click "Create codespace on main"
 1. After things spin up, you'll have [vscode](https://code.visualstudio.com/) in your browser, attached to cloud dev environment
@@ -34,9 +48,10 @@ If you have [vscode](https://code.visualstudio.com/) and [Docker](https://www.do
 
 ## Documents
 
-- [Documentation](https://pauleveritt.github.io/tagstr-site/) from this website including the [HTML tutorial](https://pauleveritt.github.io/tagstr-site/htmlbuilder.html)
-- [WIP PEP](https://github.com/jimbaker/tagstr/blob/main/pep.rst)
-- [Implementation (WIP) based on 3.14](https://github.com/lysnikolaou/cpython/tree/tag-strings-rebased)
+- [Tutorial documents](https://pauleveritt.github.io/tagstr-site/), including the [HTML tutorial](https://pauleveritt.github.io/tagstr-site/htmlbuilder.html)
+- [Tutorial notebooks](https://pauleveritt.github.io/tagstr-site/playground/lab/index.html?path=greet.ipynb)
+- [WIP PEP](https://github.com/python/peps/pull/3858)
+- [WIP `cpython` implementation based on 3.14](https://github.com/lysnikolaou/cpython/tree/tag-strings-rebased)
 
 ## Related Work
 
@@ -48,3 +63,4 @@ If you have [vscode](https://code.visualstudio.com/) and [Docker](https://www.do
 ## cpython docker images
 
 This repo has a `/docker/` submodule that contains dockerfiles used to build [Lysandros](https://github.com/lysnikolaou)' underlying [cpython branch](https://github.com/lysnikolaou/cpython/tree/tag-strings-rebased). [Koudai](https://github.com/koxudaxi) manages the submodule and also has published the images to a registry at https://hub.docker.com/r/koxudaxi/python to make them easier to use.
+

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,20 +1,11 @@
-The Project provides playground for tagged strings feature of Python 3.12.0a7. (the branch is [tag-strings-v2](https://github.com/gvanrossum/cpython/tree/tag-strings-v2))
+## Contents
 
-## Try tagged strings on jupyterlite (no installation needed)
- 
-https://pauleveritt.github.io/tagstr-site/playground/
+This directory contains [example notebooks that use tag strings](./content/).
+
+It also contains tooling to publish these notebooks as a static website, which you can [use in your browser without any installation](https://pauleveritt.github.io/tagstr-site/playground/lab/index.html?path=greet.ipynb).
 
 ![[simple](images/simple.png)](https://raw.githubusercontent.com/pauleveritt/tagstr-site/main/playground/images/simple.png)
 
+This uses the magic of [WASM](https://webassembly.org/), [pyodide](https://pyodide.org/en/stable/), and [JupyterLite](https://jupyterlite.readthedocs.io/en/stable/). We publish these changes [automatically](../.github/workflows/playground.yaml) to [github pages](https://pages.github.com/).
 
-
-## Contents
-
-The `/pyodide` directory has pyodide binary of Python 3.14.0a0([tag-strings-rebased](https://github.com/lysnikolaou/cpython/tag-strings-rebased)).
-
-The pyodide binary is build by [a fork](https://github.com/koxudaxi/pyodide/tree/support_tag-strings-rebased) of the [hoodmance's python-3.14.0a0 tag-string branch](https://github.com/hoodmane/tree/314dev-string-fmt-pep).
-
-
-# Related projects
-- https://github.com/jimbaker/tagstr
-- https://github.com/pauleveritt/fdom
+The `/pyodide` directory has pyodide binary of Python 3.14.0a0 based on the [PEP WIP implementation found here](https://github.com/lysnikolaou/cpython/tag-strings-rebased). It is built by [a fork](https://github.com/koxudaxi/pyodide/tree/support_tag-strings-rebased) of [hoodmane's python-3.14.0a0 tag-string branch](https://github.com/hoodmane/pyodide/tree/314dev-string-fmt-pep).

--- a/playground/jupyter_lite_config.json
+++ b/playground/jupyter_lite_config.json
@@ -1,6 +1,0 @@
-{
-  "PipliteAddon": {
-    "piplite_urls": [
-    ]
-  }
-}


### PR DESCRIPTION
The `dev-playground` target runs `jupyter lite serve` directly; no build step required when actively working on local notebooks.

I've also updated the `README` hopefully to add some clarity for first-time visitors about how they can engage with this content. But I imagine there's a lot more we can do here to really make things clear. :-)