### PR TITLE
Work around a problem with exception formatting in jupyter[lite].

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,9 @@
                 // Edit the devcontainer and other dockerfiles.
                 "ms-azuretools.vscode-docker",
                 // Edit the makefile
-                "ms-vscode.makefile-tools"
+                "ms-vscode.makefile-tools",
+                // Support for jupyter notebooks in vscode
+                "ms-toolsai.jupyter"
             ],
             "settings": {
                 "editor.insertSpaces": true,

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 .venv
+_output
+dist
+

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,9 @@ build-playground: install-extras check-jq
 clean-playground:
 	rm -rf playground/dist
 
-# Run a built copy of the playground locally.
 .PHONY: run-playground
 run-playground:
 	source $(VENV_PATH)/bin/activate && cd playground/dist && python -m http.server 8000
-
-# Run the jupyter lite server locally, no build step required.
-.PHONY: dev-playground
-dev-playground:
-	source $(VENV_PATH)/bin/activate && jupyter lite serve --contents playground/content --config playground/jupyter-lite.json
 
 .PHONY: check-jq
 check-jq:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ jupyterlite = [
     "jupyterlite-core[all]~=0.3.0",
     "jupyterlite-pyodide-kernel~=0.3.2",
     "ipython~=8.26.0",
+    # See https://github.com/ipython/ipython/issues/14303#issuecomment-1925423956
+    "executing@git+https://github.com/alexmojaki/executing@3.13#egg=executing",
     "sphinx-autobuild"
 ]
 


### PR DESCRIPTION
Prior to this PR, raising a simple exception in a jupyter(lite) notebook cell, like this:

```python
raise ValueError("boom")
```

Causes jupyter(lite) to raise its _own_ exception. 

The underlying issue is captured [in iPython issue 14303](https://github.com/ipython/ipython/issues/14303) and, as described there, is solved by installing the [`3.13` branch of the `executing`](https://github.com/ipython/ipython/issues/14303#issuecomment-1925423956) package.

I ran across this issue while authoring notebook content for this repo.

In addition, this PR adds a few extra directories to `.dockerignore` and installs the vscode jupyter extension by default in the devcontainer.