### PR TITLE
Install tagstr_site to playground

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Build the JupyterLite site
       run: |
-         SITE_PREFIX=/tagstr-site/playground/ make build-playground
+         SITE_PREFIX=/tagstr-site/playground/ make build-playground-without-venv
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -40,8 +40,6 @@ jobs:
     - run: python3 -m pip install -e ."[jupyterlite]"
 
     - name: Build the JupyterLite site
-      working-directory:
-        playground
       run: |
          SITE_PREFIX=/tagstr-site/playground/ make build-playground
     - name: Deploy to GitHub Pages

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Upgrade pip
       run: |
-        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade pip setuptools wheel build
 
     - name: Get pip cache dir
       id: pip-cache
@@ -43,7 +43,7 @@ jobs:
       working-directory:
         playground
       run: |
-        jupyter lite build --contents content --output-dir dist
+         SITE_PREFIX=/tagstr-site/playground/ make build-playground
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v4
       if: github.ref == 'refs/heads/main'

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -36,9 +36,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-
-    - run: python3 -m pip install -e ."[jupyterlite]"
-
+    - name: Install jupyterlite
+      run: python3 -m pip install -e ."[jupyterlite]"
+    - name: Build the package
+      run: python3 -m build
     - name: Build the JupyterLite site
       run: |
          SITE_PREFIX=/tagstr-site/playground/ make build-playground-without-venv

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ build-docs:
 	source $(VENV_PATH)/bin/activate && $(MAKE) -C docs html
 
 .PHONY: build-playground
-build-playground: install-extras check-jq wheel
-	source $(VENV_PATH)/bin/activate && cd playground && rm -fr pypi/* && cp -v ../dist/*.whl pypi/ && jupyter lite build && \
+build-playground:
+	source $(VENV_PATH)/bin/activate && $(MAKE) build-playground-without-venv
+
+.PHONY: build-playground-without-venv
+build-playground-without-venv: install-extras check-jq wheel
+	cd playground && rm -fr pypi/* && cp -v ../dist/*.whl pypi/ && jupyter lite build && \
 		WHL_FILE=$$(ls pypi | grep .whl) && \
 		jq '.["jupyter-config-data"]["litePluginSettings"]["@jupyterlite/pyodide-kernel-extension:kernel"].pyodideUrl = "https://koxudaxi.github.io/pyodide/pyodide.js"' dist/jupyter-lite.json | \
 		jq '.["jupyter-config-data"]["litePluginSettings"]["@jupyterlite/pyodide-kernel-extension:kernel"]["loadPyodideOptions"]["packages"] = ["$(SITE_PREFIX)pypi/'$$WHL_FILE'"]' > temp.json && mv temp.json dist/jupyter-lite.json

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ build-docs:
 	source $(VENV_PATH)/bin/activate && $(MAKE) -C docs html
 
 .PHONY: build-playground
-build-playground: install-extras
+build-playground: install-extras wheel
 	source $(VENV_PATH)/bin/activate && $(MAKE) build-playground-without-venv
 
 .PHONY: build-playground-without-venv
-build-playground-without-venv: check-jq wheel
+build-playground-without-venv: check-jq
 	cd playground && rm -fr pypi/* && cp -v ../dist/*.whl pypi/ && jupyter lite build && \
 		WHL_FILE=$$(ls pypi | grep .whl) && \
 		jq '.["jupyter-config-data"]["litePluginSettings"]["@jupyterlite/pyodide-kernel-extension:kernel"].pyodideUrl = "https://koxudaxi.github.io/pyodide/pyodide.js"' dist/jupyter-lite.json | \
@@ -34,6 +34,7 @@ build-playground-without-venv: check-jq wheel
 .PHONY: wheel
 wheel: clean-wheel
 	$(VENV_PATH)/bin/python -m build
+
 
 .PHONY: clean-wheel
 clean-wheel:

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ build-docs:
 	source $(VENV_PATH)/bin/activate && $(MAKE) -C docs html
 
 .PHONY: build-playground
-build-playground:
+build-playground: install-extras
 	source $(VENV_PATH)/bin/activate && $(MAKE) build-playground-without-venv
 
 .PHONY: build-playground-without-venv
-build-playground-without-venv: install-extras check-jq wheel
+build-playground-without-venv: check-jq wheel
 	cd playground && rm -fr pypi/* && cp -v ../dist/*.whl pypi/ && jupyter lite build && \
 		WHL_FILE=$$(ls pypi | grep .whl) && \
 		jq '.["jupyter-config-data"]["litePluginSettings"]["@jupyterlite/pyodide-kernel-extension:kernel"].pyodideUrl = "https://koxudaxi.github.io/pyodide/pyodide.js"' dist/jupyter-lite.json | \

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -2,3 +2,4 @@
 dist
 .cache
 .idea
+pypi/

--- a/playground/jupyter_lite_config.json
+++ b/playground/jupyter_lite_config.json
@@ -1,0 +1,8 @@
+{
+  "LiteBuildConfig": {
+    "contents": [
+      "content"
+    ],
+    "output_dir": "dist"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ jupyterlite = [
     "ipython~=8.26.0",
     # See https://github.com/ipython/ipython/issues/14303#issuecomment-1925423956
     "executing@git+https://github.com/alexmojaki/executing@3.13#egg=executing",
-    "sphinx-autobuild"
+    "sphinx-autobuild",
+    "attrs==23.2.0", # The version 24.2.0 supports only latest Python 3.14 codebase
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
 
 [project.optional-dependencies]
 jupyterlite = [
-    "jupyterlite-core[all]~=0.3.0",
-    "jupyterlite-pyodide-kernel~=0.3.2",
+    "jupyterlite-core[all]~=0.4.0",
+    "jupyterlite-pyodide-kernel~=0.4.1",
     "ipython~=8.26.0",
     # See https://github.com/ipython/ipython/issues/14303#issuecomment-1925423956
     "executing@git+https://github.com/alexmojaki/executing@3.13#egg=executing",
@@ -31,3 +31,6 @@ jupyterlite = [
 addopts = "-ra -q --doctest-modules --ignore-glob='**/_build/**'"
 # testpaths = ["docs", "tests"]
 testpaths = ["tests"]
+
+[tool.distutils.bdist_wheel]
+universal = true


### PR DESCRIPTION
The PR adds tagstr_site package to playground.
We can do `import tagstr_site` in jupyterlite.

I deployed the PR to my GitHub pages 
I have test it in my namespace on GitHub pages.
It works fine :)
https://koxudaxi.github.io/tagstr-site/playground/lab/index.html
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/a13ba542-02c9-49f3-bef2-89eb9cb65e34">
