### PR TITLE
Simple t-string and `Template` implementation

### DIFF
--- a/src/tagstr_site/experimental_tstring.py
+++ b/src/tagstr_site/experimental_tstring.py
@@ -1,0 +1,153 @@
+from typing import Iterable, TextIO, Any, Interpolation
+
+from .tstring import Template, _ValueInterpolation, _TemplateConcrete
+
+
+# NOTE WELL: this is experimental code for fun. Your mileage may vary.
+
+# -----------------------------------------------------------------------
+# An experimental method for taking an arbitrary string and converting
+# it to a Template by evaluating it with explicitly provided context.
+# -----------------------------------------------------------------------
+
+
+class _InterpolationExpr(str):
+    pass
+
+
+def _parse_str(s: str) -> Iterable[str | _InterpolationExpr]:
+    """Parse a string like it's a t-string. Kinda."""
+
+    # This is a cheap implementation for demonstration only. I doubt it
+    # handles all the cases correctly. It's also not very efficient. etc.
+
+    i = 0
+    n = len(s)
+    buffer = []
+
+    while i < n:
+        if s[i] == "{":
+            if i + 1 < n and s[i + 1] == "{":
+                buffer.append("{")
+                i += 2
+            else:
+                if buffer:
+                    yield "".join(buffer)
+                    buffer = []
+                i += 1
+                brace_start = i
+                depth = 1
+                while i < n and depth > 0:
+                    if s[i] == "{":
+                        depth += 1
+                    elif s[i] == "}":
+                        depth -= 1
+                    i += 1
+                if depth != 0:
+                    raise SyntaxError("t-string: expecting '}'")
+                yield _InterpolationExpr(s[brace_start : i - 1])
+        elif s[i] == "}":
+            if i + 1 < n and s[i + 1] == "}":
+                buffer.append("}")
+                i += 2
+            else:
+                raise SyntaxError("t-string: expecting '}'")
+        else:
+            buffer.append(s[i])
+            i += 1
+
+    if buffer:
+        yield "".join(buffer)
+
+
+def make_template(source: TextIO | str, context: dict[str, Any]) -> Template:
+    """
+    Read a template from a file-like object or a `str` and return a `Template`
+    instance.
+
+    Use the provided `context` dictionary to evaluate the template string.
+    """
+    source = source if isinstance(source, str) else source.read()
+    args: list[Interpolation | str] = []
+    for part in _parse_str(source):
+        if isinstance(part, _InterpolationExpr):
+            value = eval(part, context)
+            # TODO support Interpolation.conv and .format_spec
+            args.append(_ValueInterpolation(value, part, None, None))
+        else:
+            # TODO create a concrete Decoded class and handle .raw
+            args.append(part)
+    return _TemplateConcrete(tuple(args), source)
+
+
+# >>> from tagstr_site.tstring import make_template
+# >>> x = make_template("{a} and {b}", {"a": 10, "b": 42})
+# >>> x
+# <tagstr_site.tstring._TemplateConcrete object at 0x7f4c1c1b1d60>
+# >>> x.source
+# '{a} and {b}'
+# >>> x.args[0]
+# <tagstr_site.tstring._ValueInterpolation object at 0xffffb7463b10>>
+# >>> x.args[0].value
+# 10
+# >>> x.args[1]
+# ' and '
+# >>> x.args[2].value
+# 42
+
+
+# -----------------------------------------------------------------------
+# A hacknological experimental method for taking an arbitrary string
+# and converting it to a Template by evaluating it with the caller's
+# context.
+# -----------------------------------------------------------------------
+
+
+def as_t(text: TextIO | str) -> Template:
+    """
+    Read a template from a file-like object and return a `Template` object
+    by evaluating the text as a template string *in the caller's context*.
+    """
+    # This is HACKNOLOGY that follows a question by Paul in our Discord chat.
+    import inspect
+
+    frame = inspect.currentframe()
+    assert frame is not None
+    calling_frame = frame.f_back
+    assert calling_frame is not None
+
+    # make sure the `t` function is available in the eval context; wouldn't
+    # be necessary if cpython supported t-strings directly
+    dunder = "__as_t__t__"
+    calling_globals = dict(calling_frame.f_globals)
+    assert dunder not in calling_globals
+    calling_globals[dunder] = t
+
+    # Build an expression that evaluates to the template string.
+    s = text if isinstance(text, str) else text.read()
+    texpr = f"{dunder}\"{s.replace('"', '\\"')}\""
+
+    # XXX I expect that setting `locals=calling_frame.f_locals` rather than
+    # merging the two dicts should work fine, but it doesn't. A bug?
+    template = eval(texpr, {**calling_globals, **calling_frame.f_locals})
+    assert isinstance(template, Template)
+    return template
+
+
+# >>> from tagstr_site.tstring import as_t
+# >>> g = 42
+# >>> def f():
+# ...     l = 10
+# ...     return as_t("{l} and {g}")
+# ...
+# >>> x = f()
+# >>> x
+# <tagstr_site.tstring._TemplateConcrete object at 0x7f4c1c1b1d60>
+# >>> x.source
+# '{l} and {g}'
+# >>> x.args[0].value
+# 10
+# >>> x.args[1]
+# DecodedConcrete(' and ')
+# >>> x.args[2].value
+# 42

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -16,6 +16,7 @@ class Template[T](Protocol):
 
 class _EagerInterpolation(Interpolation):
     def __init__(self, interpolation: Interpolation):
+        # For now, support both `.value` *and* `.getvalue()`.
         self.value = interpolation.getvalue()
         self.expr = interpolation.expr
         self.conv = interpolation.conv

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -47,6 +47,8 @@ class TemplateConcrete[T](Template[T]):
 
 def t(*args: Interpolation | Decoded) -> Template:
     eager_args = tuple(EagerInterpolationConcrete(arg) if isinstance(arg, Interpolation) else arg for arg in args)
+    # XXX in the "real" implementation, `Template.source` will be something we 
+    # can memoize off of; that's not the case in this makeshift implementation.
     # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
     source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
     return TemplateConcrete(eager_args, source)

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -1,4 +1,17 @@
-from typing import Interpolation, Decoded, Protocol, runtime_checkable, Annotated, TextIO
+from typing import (
+    Annotated,
+    Any,
+    Interpolation,
+    Iterable,
+    Protocol,
+    runtime_checkable,
+    TextIO,
+)
+
+# -----------------------------------------------------------------------
+# A simple "implementation" of proposed t-strings, using the older
+# PEP 750 tag string behavior.
+# -----------------------------------------------------------------------
 
 
 @runtime_checkable
@@ -6,52 +19,57 @@ class Template[T](Protocol):
     # CONSIDER What is T useful for?
 
     @property
-    def args(self) -> tuple[Interpolation | Decoded, ...]:
-        ...
+    def args(self) -> tuple[Interpolation | str, ...]: ...
 
     @property
-    def source(self) -> str:
-        ...
+    def source(self) -> str: ...
 
 
-class EagerInterpolationConcrete(Interpolation):
-    def __init__(self, interpolation: Interpolation):
-        # For now, support both `.value` *and* `.getvalue()`.
-        self.value = interpolation.getvalue()
-        self.expr = interpolation.expr
-        self.conv = interpolation.conv
-        self.format_spec = interpolation.format_spec
+class _ValueInterpolation(Interpolation):
+    def __init__(
+        self, value: Any, expr: str, conv: str | None, format_spec: str | None
+    ):
+        self.value = value
+        self.expr = expr
+        self.conv = conv
+        self.format_spec = format_spec
 
     def getvalue(self) -> str:
         return self.value
 
 
-class TemplateConcrete[T](Template[T]):
-    _args: tuple[Interpolation | Decoded, ...]
+class _TemplateConcrete[T](Template[T]):
+    _args: tuple[Interpolation | str, ...]
     _source: str
 
-    def __init__(self, args: tuple[Interpolation | Decoded, ...], source: str):
+    def __init__(self, args: tuple[Interpolation | str, ...], source: str):
         self._args = args
         self._source = source
 
     @property
-    def args(self) -> tuple[Interpolation | Decoded, ...]:
+    def args(self) -> tuple[Interpolation | str, ...]:
         return self._args
 
     @property
     def source(self) -> str:
         return self._source
 
-    # CONSIDER __str__(self) returns `self.source`?
+    # CONSIDER what should __str__(self) return?
 
 
-def t(*args: Interpolation | Decoded) -> Template:
-    eager_args = tuple(EagerInterpolationConcrete(arg) if isinstance(arg, Interpolation) else arg for arg in args)
-    # XXX support Interpolation.conv and .format_spec
+def t(*args: Interpolation | str) -> Template:
+    eager_args = tuple(
+        _ValueInterpolation(arg.getvalue(), arg.expr, arg.conv, arg.format_spec)  # type: ignore
+        if isinstance(arg, Interpolation)
+        else arg
+        for arg in args
+    )
+    # TODO support Interpolation.conv and .format_spec
     # XXX possibly we want `arg.raw` when `arg` is `Decoded`?
-    source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
-    return TemplateConcrete(eager_args, source)
-
+    source = "".join(
+        f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args  # type: ignore
+    )
+    return _TemplateConcrete(eager_args, source)
 
 
 # >>> from tagstr_site.tstring import t
@@ -60,9 +78,108 @@ def t(*args: Interpolation | Decoded) -> Template:
 # 'hello {42}'
 # >>> x.args[0]
 # DecodedConcrete('hello ')
+# >>> x.args[1]
+# <tagstr_site.tstring._ValueInterpolation object at 0xffffb72541a0>
 # >>> x.args[1].value
 # 42
 
+
+# -----------------------------------------------------------------------
+# An experimental method for taking an arbitrary string and converting
+# it to a Template by evaluating it with explicitly provided context.
+# -----------------------------------------------------------------------
+
+
+class _InterpolationExpr(str):
+    pass
+
+
+def _parse_str(s: str) -> Iterable[str | _InterpolationExpr]:
+    """Parse a string like it's a t-string. Kinda."""
+
+    # This is a cheap implementation for demonstration only. I doubt it
+    # handles all the cases correctly. It's also not very efficient. etc.
+
+    i = 0
+    n = len(s)
+    buffer = []
+
+    while i < n:
+        if s[i] == "{":
+            if i + 1 < n and s[i + 1] == "{":
+                buffer.append("{")
+                i += 2
+            else:
+                if buffer:
+                    yield "".join(buffer)
+                    buffer = []
+                i += 1
+                brace_start = i
+                depth = 1
+                while i < n and depth > 0:
+                    if s[i] == "{":
+                        depth += 1
+                    elif s[i] == "}":
+                        depth -= 1
+                    i += 1
+                if depth != 0:
+                    raise SyntaxError("t-string: expecting '}'")
+                yield _InterpolationExpr(s[brace_start : i - 1])
+        elif s[i] == "}":
+            if i + 1 < n and s[i + 1] == "}":
+                buffer.append("}")
+                i += 2
+            else:
+                raise SyntaxError("t-string: expecting '}'")
+        else:
+            buffer.append(s[i])
+            i += 1
+
+    if buffer:
+        yield "".join(buffer)
+
+
+def make_template(source: TextIO | str, context: dict[str, Any]) -> Template:
+    """
+    Read a template from a file-like object or a `str` and return a `Template`
+    instance.
+
+    Use the provided `context` dictionary to evaluate the template string.
+    """
+    source = source if isinstance(source, str) else source.read()
+    args: list[Interpolation | str] = []
+    for part in _parse_str(source):
+        if isinstance(part, _InterpolationExpr):
+            value = eval(part, context)
+            # TODO support Interpolation.conv and .format_spec
+            args.append(_ValueInterpolation(value, part, None, None))
+        else:
+            # TODO create a concrete Decoded class and handle .raw
+            args.append(part)
+    return _TemplateConcrete(tuple(args), source)
+
+
+# >>> from tagstr_site.tstring import make_template
+# >>> x = make_template("{a} and {b}", {"a": 10, "b": 42})
+# >>> x
+# <tagstr_site.tstring._TemplateConcrete object at 0x7f4c1c1b1d60>
+# >>> x.source
+# '{a} and {b}'
+# >>> x.args[0]
+# <tagstr_site.tstring._ValueInterpolation object at 0xffffb7463b10>>
+# >>> x.args[0].value
+# 10
+# >>> x.args[1]
+# ' and '
+# >>> x.args[2].value
+# 42
+
+
+# -----------------------------------------------------------------------
+# A hacknological experimental method for taking an arbitrary string
+# and converting it to a Template by evaluating it with the caller's
+# context.
+# -----------------------------------------------------------------------
 
 
 def as_t(text: TextIO | str) -> Template:
@@ -70,8 +187,9 @@ def as_t(text: TextIO | str) -> Template:
     Read a template from a file-like object and return a `Template` object
     by evaluating the text as a template string *in the caller's context*.
     """
-    # This is hacknology that follows a question by Paul in our Discord chat.
+    # This is HACKNOLOGY that follows a question by Paul in our Discord chat.
     import inspect
+
     frame = inspect.currentframe()
     assert frame is not None
     calling_frame = frame.f_back
@@ -85,30 +203,30 @@ def as_t(text: TextIO | str) -> Template:
     calling_globals[dunder] = t
 
     # Build an expression that evaluates to the template string.
-    s = (text if isinstance(text, str) else text.read())
+    s = text if isinstance(text, str) else text.read()
     texpr = f"{dunder}\"{s.replace('"', '\\"')}\""
 
     # XXX I expect that setting `locals=calling_frame.f_locals` rather than
     # merging the two dicts should work fine, but it doesn't. A bug?
-    template = eval(texpr, globals={**calling_globals, **calling_frame.f_locals})
+    template = eval(texpr, {**calling_globals, **calling_frame.f_locals})
     assert isinstance(template, Template)
     return template
 
 
-# >>> from io import StringIO
 # >>> from tagstr_site.tstring import as_t
 # >>> g = 42
 # >>> def f():
 # ...     l = 10
-# ...     return as_t(StringIO("{l} and {g}"))
+# ...     return as_t("{l} and {g}")
 # ...
-# >>> f()
-# <tagstr_site.tstring.TemplateConcrete object at 0x7f4c1c1b1d60>
-# >>> f().source
+# >>> x = f()
+# >>> x
+# <tagstr_site.tstring._TemplateConcrete object at 0x7f4c1c1b1d60>
+# >>> x.source
 # '{l} and {g}'
-# >>> f().args[0].value
+# >>> x.args[0].value
 # 10
-# >>> f().args[1]
+# >>> x.args[1]
 # DecodedConcrete(' and ')
-# >>> f().args[2].value
+# >>> x.args[2].value
 # 42

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -3,7 +3,7 @@ from typing import Interpolation, Decoded, Protocol, runtime_checkable, Annotate
 
 @runtime_checkable
 class Template[T](Protocol):
-    # TODO What about Template[T]? What would [T] even be?
+    # CONSIDER What is T useful for?
 
     @property
     def args(self) -> tuple[Interpolation | Decoded, ...]:
@@ -49,6 +49,3 @@ def t(*args: Interpolation | Decoded) -> Template:
     # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
     source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
     return TemplateConcrete(eager_args, source)
-
-
-

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -1,0 +1,54 @@
+from typing import Interpolation, Decoded, Protocol, runtime_checkable, Annotated
+
+
+@runtime_checkable
+class Template[T](Protocol):
+    # TODO What about Template[T]? What would [T] even be?
+
+    @property
+    def args(self) -> tuple[Interpolation | Decoded, ...]:
+        ...
+
+    @property
+    def source(self) -> str:
+        ...
+
+
+class _EagerInterpolation(Interpolation):
+    def __init__(self, interpolation: Interpolation):
+        self.value = interpolation.getvalue()
+        self.expr = interpolation.expr
+        self.conv = interpolation.conv
+        self.format_spec = interpolation.format_spec
+
+    def getvalue(self) -> str:
+        return self.value
+
+
+class TemplateConcrete[T](Template[T]):
+    _args: tuple[Interpolation | Decoded, ...]
+    _source: str
+
+    def __init__(self, args: tuple[Interpolation | Decoded, ...], source: str):
+        self._args = args
+        self._source = source
+
+    @property
+    def args(self) -> tuple[Interpolation | Decoded, ...]:
+        return self._args
+
+    @property
+    def source(self) -> str:
+        return self._source
+
+    # CONSIDER __str__(self) returns `self.source`?
+
+
+def t(*args: Interpolation | Decoded) -> Template:
+    eager_args = tuple(_EagerInterpolation(arg) if isinstance(arg, Interpolation) else arg for arg in args)
+    # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
+    source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
+    return TemplateConcrete(eager_args, source)
+
+
+

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -47,7 +47,8 @@ class TemplateConcrete[T](Template[T]):
 
 def t(*args: Interpolation | Decoded) -> Template:
     eager_args = tuple(EagerInterpolationConcrete(arg) if isinstance(arg, Interpolation) else arg for arg in args)
-    # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
+    # XXX support Interpolation.conv and .format_spec
+    # XXX possibly we want `arg.raw` when `arg` is `Decoded`?
     source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
     return TemplateConcrete(eager_args, source)
 

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -14,7 +14,7 @@ class Template[T](Protocol):
         ...
 
 
-class _EagerInterpolation(Interpolation):
+class EagerInterpolationConcrete(Interpolation):
     def __init__(self, interpolation: Interpolation):
         # For now, support both `.value` *and* `.getvalue()`.
         self.value = interpolation.getvalue()
@@ -46,7 +46,18 @@ class TemplateConcrete[T](Template[T]):
 
 
 def t(*args: Interpolation | Decoded) -> Template:
-    eager_args = tuple(_EagerInterpolation(arg) if isinstance(arg, Interpolation) else arg for arg in args)
+    eager_args = tuple(EagerInterpolationConcrete(arg) if isinstance(arg, Interpolation) else arg for arg in args)
     # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
     source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
     return TemplateConcrete(eager_args, source)
+
+
+
+# >>> from tagstr_site.tstring import t
+# >>> x = t"hello {42}"
+# >>> x.source
+# 'hello {42}'
+# >>> x.args[0]
+# DecodedConcrete('hello ')
+# >>> x.args[1].value
+# 42

--- a/src/tagstr_site/tstring.py
+++ b/src/tagstr_site/tstring.py
@@ -47,8 +47,6 @@ class TemplateConcrete[T](Template[T]):
 
 def t(*args: Interpolation | Decoded) -> Template:
     eager_args = tuple(EagerInterpolationConcrete(arg) if isinstance(arg, Interpolation) else arg for arg in args)
-    # XXX in the "real" implementation, `Template.source` will be something we 
-    # can memoize off of; that's not the case in this makeshift implementation.
     # XXX possibly we want `else arg.raw` if `arg` is `Decoded`?
     source = "".join(f"{{{arg.expr}}}" if isinstance(arg, Interpolation) else arg for arg in args)
     return TemplateConcrete(eager_args, source)

--- a/tests/test_tstring.py
+++ b/tests/test_tstring.py
@@ -1,0 +1,41 @@
+from typing import Interpolation
+from tagstr_site.tstring import t, Template
+
+
+def test_empty():
+    template = t""
+    assert isinstance(template, Template)
+    assert len(template.args) == 1
+    assert template.args[0] == ""
+    assert template.source == ("",)
+
+def test_simple():
+    template = t"hello"
+    assert isinstance(template, Template)
+    assert len(template.args) == 1
+    assert template.args[0] == "hello"
+    assert template.source == ("hello",)
+
+def test_only_interpolation():
+    template = t"{42}"
+    assert isinstance(template, Template)
+    assert len(template.args) == 3
+    assert template.args[0] == ""
+    assert isinstance(template.args[1], Interpolation)
+    assert template.args[1].value == 42
+    assert template.args[2] == ""
+    assert template.source == ("", "")
+
+def test_mixed():
+    v = 99
+    template = t"hello{42}world{v}goodbye"
+    assert isinstance(template, Template)
+    assert len(template.args) == 5
+    assert template.args[0] == "hello"
+    assert isinstance(template.args[1], Interpolation)
+    assert template.args[1].value == 42
+    assert template.args[2] == "world"
+    assert isinstance(template.args[3], Interpolation)
+    assert template.args[3].value == v
+    assert template.args[4] == "goodbye"
+    assert template.source == ("hello", "world", "goodbye")


### PR DESCRIPTION
This PR provides a `t` method that matches the proposed semantics of our `t-string` PEP 750. 

**Updated** on Friday, September 20 to support even/odd behavior, as seen here:

```
# >>> from tagstr_site.tstring import t
# >>> x = t"hello {42}"
# >>> x
# <tagstr_site.tstring._TemplateConcrete object at 0x12345676>
# >>> x.source
# (DecodedConcrete('hello '), "")
# >>> x.raw
# 'hello {42}'
# >>> x.args[0]
# DecodedConcrete('hello ')
# >>> x.args[1]
# <tagstr_site.tstring._ValueInterpolation object at 0xffffb72541a0>
# >>> x.args[1].value
# 42
# >>> x.args[2]
# ''
```

This is built on the _older_ version of PEP 750, with support for arbitrary tags.

**NOTE** The current fork of `cpython` that we're using makes it hard to create our own concrete instance of `Decoded`, so there are cases where we use `str` instead.