### PR TITLE
Update executing version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ jupyterlite = [
     "jupyterlite-core[all]~=0.4.0",
     "jupyterlite-pyodide-kernel~=0.4.1",
     "ipython~=8.26.0",
-    # See https://github.com/ipython/ipython/issues/14303#issuecomment-1925423956
-    "executing@git+https://github.com/alexmojaki/executing@3.13#egg=executing",
+    "executing~=2.1.0",
     "sphinx-autobuild",
     "attrs==23.2.0", # The version 24.2.0 supports only latest Python 3.14 codebase
 ]


### PR DESCRIPTION
Related PR: https://github.com/pauleveritt/tagstr-site/pull/34
@davepeck @pauleveritt 
The PR fixes CI build error.
https://github.com/alexmojaki/executing/commit/8827340e154c557b64fda9ee50115bc958da20dc

Now, executing supports Python3.13. We don't need to install it from the branch.
